### PR TITLE
Added support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 2.1.4


### PR DESCRIPTION
We’re only testing ruby-2.1.4 for the time being.